### PR TITLE
Add sad path test for createWatchlistItem

### DIFF
--- a/spec/requests/create_watchlist_item_spec.rb
+++ b/spec/requests/create_watchlist_item_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe "CreateWatchlistItem", type: :request do
         )
     end
 
+    describe 'sad paths' do 
+      it 'returns errors if arguments are missing' do 
+        post '/graphql', params: { query: empty_query }
+        json = JSON.parse(response.body, symbolize_names: true)
+  
+        expect(json).to have_key(:errors)
+        expect(json[:errors].first).to have_key(:message)
+        expect(json[:errors].first[:message]).to eq("Field 'createWatchlistItem' is missing required arguments: tmdbId, userId, mediaType")
+      end
+    end
+
     def query(user_id)
       <<~GQL
       mutation
@@ -39,6 +50,28 @@ RSpec.describe "CreateWatchlistItem", type: :request do
         tmdbId
         userId
         mediaType
+        }
+       }
+     GQL
+    end
+
+    def empty_query
+      <<~GQL
+      mutation
+       { createWatchlistItem
+        {
+        id
+        }
+       }
+     GQL
+    end
+
+    def bad_query(user_id)
+      <<~GQL
+      mutation
+       { createWatchlistItem(tmdbId: 10, userId: #{user_id}, mediaType: "thing" )
+        {
+        id
         }
        }
      GQL


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Neccesary checkmarks:

    [x] All Tests are Passing in all environments

    [x] The code will run locally

## Type of change

    [x] New feature
    [] Bug Fix
    [] Refactor

## Description of Change:

    description: Added a sad path test for if arguments are not provided when creating a new watchlist item.
    
## Requested feedback: 
    
    I'd like feedback on... Test robustness

## Check the correct boxes

    [x] This broke nothing
    [] This broke some stuff
    [] This broke everything

## Testing Changes

    [] No Tests have been changed
    [x] Some Tests have been changed
    [] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

    [x] My code has no unused/commented out code
    [x] My code has no binding.pry's
    [x] I have reviewed my code
    [] I have commented my code, particularly in hard-to-understand areas
    [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link: